### PR TITLE
Fix arrow key handling in Ink input

### DIFF
--- a/src/input/keybindings.ts
+++ b/src/input/keybindings.ts
@@ -1,18 +1,36 @@
-import { GameAction } from './actions';
+import type { Key } from 'ink';
+import { GameAction } from './actions.js';
 
-// This maps Ink's key object properties to our abstract GameActions.
-export const keybindings: Record<string, GameAction> = {
-	w: GameAction.MOVE_NORTH,
-	arrowUp: GameAction.MOVE_NORTH,
-
-	s: GameAction.MOVE_SOUTH,
-	arrowDown: GameAction.MOVE_SOUTH,
-
-	d: GameAction.MOVE_EAST,
-	arrowRight: GameAction.MOVE_EAST,
-
-	a: GameAction.MOVE_WEST,
-	arrowLeft: GameAction.MOVE_WEST,
-
-	q: GameAction.QUIT,
+const characterBindings: Record<string, GameAction> = {
+  w: GameAction.MOVE_NORTH,
+  s: GameAction.MOVE_SOUTH,
+  d: GameAction.MOVE_EAST,
+  a: GameAction.MOVE_WEST,
+  q: GameAction.QUIT,
 };
+
+export function resolveAction(input: string, key: Key): GameAction | undefined {
+  const normalizedInput = input.toLowerCase();
+
+  if (normalizedInput && characterBindings[normalizedInput]) {
+    return characterBindings[normalizedInput];
+  }
+
+  if (key.upArrow) {
+    return GameAction.MOVE_NORTH;
+  }
+
+  if (key.downArrow) {
+    return GameAction.MOVE_SOUTH;
+  }
+
+  if (key.rightArrow) {
+    return GameAction.MOVE_EAST;
+  }
+
+  if (key.leftArrow) {
+    return GameAction.MOVE_WEST;
+  }
+
+  return undefined;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { render, useApp, useInput } from 'ink';
 import { getInitialState, update } from './engine/game.js';
 import { GameAction } from './input/actions.js';
-import { keybindings } from './input/keybindings.js';
+import { resolveAction } from './input/keybindings.js';
 import MapView from './components/MapView.js';
 import type { GameState } from './engine/state.js';
 
@@ -27,9 +27,7 @@ const App = () => {
 		}
 
 		// Determine the action from the keybinding map.
-		// `key.name` is for special keys (e.g., 'arrowUp'), `input` is for regular chars.
-		const actionKey = key.name || input;
-		const action = keybindings[actionKey];
+		const action = resolveAction(input, key);
 
 		if (action) {
 			const newState = update(state, action);


### PR DESCRIPTION
## Summary
- add a resolveAction helper that maps both character keys and Ink's arrow key flags to game actions
- update the Ink input handler to use the helper so arrow keys and uppercase movement keys advance the player

## Testing
- npm run build *(fails: existing TypeScript configuration is missing Node typings and explicit file extensions in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df178b48b4832b8965a3386a5e8282