### PR TITLE
Fix north movement key detection

### DIFF
--- a/src/input/keybindings.ts
+++ b/src/input/keybindings.ts
@@ -12,7 +12,10 @@ const characterBindings: Record<string, GameAction> = {
 export function resolveAction(input: string, key: Key): GameAction | undefined {
   const normalizedInput = input.toLowerCase();
 
-  if (normalizedInput && characterBindings[normalizedInput]) {
+  if (
+    normalizedInput &&
+    Object.prototype.hasOwnProperty.call(characterBindings, normalizedInput)
+  ) {
     return characterBindings[normalizedInput];
   }
 


### PR DESCRIPTION
## Summary
- ensure the WASD keybinding lookup does not treat MOVE_NORTH as falsy
- allow resolving the northward movement when pressing "w"

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68df485cd3e8832b9198a4ef4addf118