### PR TITLE
Fix handling of northward movement input

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { GameState } from '../engine/state';
+import type { GameState } from '../engine/state.js';
 
 interface Props {
 	state: GameState;

--- a/src/input/keybindings.ts
+++ b/src/input/keybindings.ts
@@ -12,7 +12,10 @@ const characterBindings: Record<string, GameAction> = {
 export function resolveAction(input: string, key: Key): GameAction | undefined {
   const normalizedInput = input.toLowerCase();
 
-  if (normalizedInput && characterBindings[normalizedInput]) {
+  if (
+    normalizedInput &&
+    Object.prototype.hasOwnProperty.call(characterBindings, normalizedInput)
+  ) {
     return characterBindings[normalizedInput];
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,21 +19,20 @@ const App = () => {
 		}
 	}, [state.message, exit]);
 
-	useInput((input, key) => {
-		// Allow Ctrl+C to exit at any time.
-		if (key.ctrl && input === 'c') {
-			setState(update(state, GameAction.QUIT));
-			return;
-		}
+        useInput((input, key) => {
+                // Allow Ctrl+C to exit at any time.
+                if (key.ctrl && input === 'c') {
+                        setState((prev) => update(prev, GameAction.QUIT));
+                        return;
+                }
 
-		// Determine the action from the keybinding map.
-		const action = resolveAction(input, key);
+                // Determine the action from the keybinding map.
+                const action = resolveAction(input, key);
 
-		if (action) {
-			const newState = update(state, action);
-			setState(newState);
-		}
-	});
+                if (action !== undefined) {
+                        setState((prev) => update(prev, action));
+                }
+        });
 
 	return <MapView state={state} />;
 };


### PR DESCRIPTION
## Summary
- ensure the input handler updates state even when MOVE_NORTH resolves to 0 by checking for undefined explicitly
- use functional state updates for all inputs to avoid stale state usage
- fix the MapView game state import to comply with NodeNext module resolution

## Testing
- `npm run build` *(fails: missing Node.js type declarations for fs/path/url in current setup)*

------
https://chatgpt.com/codex/tasks/task_e_68df485cd3e8832b9198a4ef4addf118