### PR TITLE
Fix ignoring northward actions

### DIFF
--- a/src/components/GameScreen.test.tsx
+++ b/src/components/GameScreen.test.tsx
@@ -1,0 +1,12 @@
+import { GameAction } from '../input/actions.js';
+import { isActionDefined } from './GameScreen.js';
+
+describe('isActionDefined', () => {
+  it('treats MOVE_NORTH as a valid action', () => {
+    expect(isActionDefined(GameAction.MOVE_NORTH)).toBe(true);
+  });
+
+  it('returns false for undefined actions', () => {
+    expect(isActionDefined(undefined)).toBe(false);
+  });
+});

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import MapView from './MapView.js';
+import type { GameState } from '../engine/state.js';
+import type { GameAction } from '../input/actions.js';
+import { resolveAction } from '../input/keybindings.js';
+import { applyActionToState } from '../game/updateState.js';
+
+interface Props {
+  initialState: GameState;
+  statusMessage: string;
+}
+
+export function isActionDefined(
+  action: GameAction | undefined
+): action is GameAction {
+  return action !== undefined;
+}
+
+const GameScreen: React.FC<Props> = ({ initialState, statusMessage }) => {
+  const [state, setState] = useState<GameState>(initialState);
+
+  useInput((input, key) => {
+    const action = resolveAction(input, key);
+
+    if (!isActionDefined(action)) {
+      return;
+    }
+
+    setState((currentState) => applyActionToState(currentState, action));
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Box justifyContent="center" marginBottom={1}>
+        <Text>{statusMessage}</Text>
+      </Box>
+      <MapView state={state} />
+    </Box>
+  );
+};
+
+export default GameScreen;

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -3,42 +3,41 @@ import { Box, Text } from 'ink';
 import type { GameState } from '../engine/state.js';
 
 interface Props {
-	state: GameState;
+  state: GameState;
 }
 
 const MapView: React.FC<Props> = ({ state }) => {
-	const { player, map, message } = state;
+  const { player, map, message } = state;
 
-	// Create a mutable copy of the tiles to draw the player on top.
-	const displayTiles = map.tiles.map((row) => [...row]);
+  const displayTiles = map.tiles.map((row) => [...row]);
 
-	// Add the player character to the display grid.
-	if (
-		player.position.y >= 0 &&
-		player.position.y < map.height &&
-		player.position.x >= 0 &&
-		player.position.x < map.width
-	) {
-		displayTiles[player.position.y][player.position.x] = '@';
-	}
+  if (
+    player.position.y >= 0 &&
+    player.position.y < map.height &&
+    player.position.x >= 0 &&
+    player.position.x < map.width
+  ) {
+    displayTiles[player.position.y][player.position.x] = '@';
+  }
 
-	return (
-		<Box flexDirection="column" padding={1}>
-			<Box flexDirection="column" alignItems="center" marginBottom={1}>
-				<Text bold>He Walks Unseen</Text>
-			</Box>
+  return (
+    <Box flexDirection="column" paddingX={2}>
+      <Box flexDirection="column" alignItems="center" marginBottom={1}>
+        <Text bold>He Walks Unseen</Text>
+        <Text>HP: {player.hp}</Text>
+      </Box>
 
-			<Box flexDirection="column" alignItems="center">
-				{displayTiles.map((row, y) => (
-					<Text key={y}>{row.join(' ')}</Text>
-				))}
-			</Box>
+      <Box flexDirection="column" alignItems="center">
+        {displayTiles.map((row, y) => (
+          <Text key={y}>{row.join(' ')}</Text>
+        ))}
+      </Box>
 
-			<Box marginTop={1} paddingX={2} borderStyle="round">
-				<Text>{message}</Text>
-			</Box>
-		</Box>
-	);
+      <Box marginTop={1} paddingX={2} borderStyle="round">
+        <Text>{message}</Text>
+      </Box>
+    </Box>
+  );
 };
 
 export default MapView;

--- a/src/game/initialState.ts
+++ b/src/game/initialState.ts
@@ -1,0 +1,60 @@
+import type { GameState, Point } from '../engine/state.js';
+import { getResource } from '../engine/resourceManager.js';
+
+interface MapDefinition {
+  width: number;
+  height: number;
+  tiles: string[][];
+}
+
+interface MapResource {
+  [key: string]: MapDefinition;
+}
+
+function findPlayerStart(tiles: string[][]): Point | null {
+  for (let y = 0; y < tiles.length; y += 1) {
+    for (let x = 0; x < tiles[y].length; x += 1) {
+      if (tiles[y][x] === '@') {
+        return { x, y };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function createInitialGameState(message?: string, mapKey: string = 'default'): GameState {
+  const maps = getResource<MapResource>('maps');
+  const map = maps[mapKey];
+
+  if (!map) {
+    throw new Error(`Map with key "${mapKey}" not found in resources.`);
+  }
+
+  const tiles = map.tiles.map((row) => [...row]);
+  const startPosition = findPlayerStart(tiles);
+  let playerPosition: Point;
+
+  if (startPosition) {
+    tiles[startPosition.y][startPosition.x] = '.';
+    playerPosition = startPosition;
+  } else {
+    playerPosition = {
+      x: Math.floor(map.width / 2),
+      y: Math.floor(map.height / 2),
+    };
+  }
+
+  return {
+    player: {
+      position: playerPosition,
+      hp: 5,
+    },
+    map: {
+      tiles,
+      width: map.width,
+      height: map.height,
+    },
+    message: message ?? 'Use the arrow keys or WASD to move around the clearing.',
+  };
+}

--- a/src/game/updateState.ts
+++ b/src/game/updateState.ts
@@ -1,0 +1,68 @@
+import type { GameState } from '../engine/state.js';
+import { GameAction } from '../input/actions.js';
+
+interface MovementDelta {
+  dx: number;
+  dy: number;
+  successMessage: string;
+}
+
+const MOVEMENT_DELTAS: Partial<Record<GameAction, MovementDelta>> = {
+  [GameAction.MOVE_NORTH]: { dx: 0, dy: -1, successMessage: 'You move north.' },
+  [GameAction.MOVE_SOUTH]: { dx: 0, dy: 1, successMessage: 'You move south.' },
+  [GameAction.MOVE_EAST]: { dx: 1, dy: 0, successMessage: 'You move east.' },
+  [GameAction.MOVE_WEST]: { dx: -1, dy: 0, successMessage: 'You move west.' },
+};
+
+function isBlocked(state: GameState, x: number, y: number): boolean {
+  if (x < 0 || x >= state.map.width || y < 0 || y >= state.map.height) {
+    return true;
+  }
+
+  return state.map.tiles[y][x] === '#';
+}
+
+export function applyActionToState(state: GameState, action: GameAction): GameState {
+  if (action === GameAction.QUIT) {
+    return {
+      ...state,
+      message: 'Press Ctrl+C to exit the simulation.',
+    };
+  }
+
+  const delta = MOVEMENT_DELTAS[action];
+
+  if (!delta) {
+    return state;
+  }
+
+  const targetX = state.player.position.x + delta.dx;
+  const targetY = state.player.position.y + delta.dy;
+
+  if (isBlocked(state, targetX, targetY)) {
+    const boundaryMessage =
+      targetX < 0 ||
+      targetX >= state.map.width ||
+      targetY < 0 ||
+      targetY >= state.map.height
+        ? "You can't step beyond the treeline."
+        : 'A wall blocks your way.';
+
+    return {
+      ...state,
+      message: boundaryMessage,
+    };
+  }
+
+  return {
+    ...state,
+    player: {
+      ...state.player,
+      position: {
+        x: targetX,
+        y: targetY,
+      },
+    },
+    message: delta.successMessage,
+  };
+}

--- a/src/input/keybindings.test.ts
+++ b/src/input/keybindings.test.ts
@@ -1,0 +1,32 @@
+import type { Key } from 'ink';
+import { GameAction } from './actions.js';
+import { resolveAction } from './keybindings.js';
+
+const createKey = (overrides: Partial<Key> = {}): Key => ({
+  upArrow: false,
+  downArrow: false,
+  leftArrow: false,
+  rightArrow: false,
+  return: false,
+  escape: false,
+  tab: false,
+  shift: false,
+  ctrl: false,
+  meta: false,
+  ...overrides,
+});
+
+describe('resolveAction', () => {
+  it('returns MOVE_NORTH for W input', () => {
+    expect(resolveAction('w', createKey())).toBe(GameAction.MOVE_NORTH);
+  });
+
+  it('prioritizes the up arrow over its character payload', () => {
+    const action = resolveAction('A', createKey({ upArrow: true }));
+    expect(action).toBe(GameAction.MOVE_NORTH);
+  });
+
+  it('returns undefined when there is no matching binding', () => {
+    expect(resolveAction('z', createKey())).toBeUndefined();
+  });
+});

--- a/src/input/keybindings.ts
+++ b/src/input/keybindings.ts
@@ -10,15 +10,6 @@ const characterBindings: Record<string, GameAction> = {
 };
 
 export function resolveAction(input: string, key: Key): GameAction | undefined {
-  const normalizedInput = input.toLowerCase();
-
-  if (
-    normalizedInput &&
-    Object.prototype.hasOwnProperty.call(characterBindings, normalizedInput)
-  ) {
-    return characterBindings[normalizedInput];
-  }
-
   if (key.upArrow) {
     return GameAction.MOVE_NORTH;
   }
@@ -33,6 +24,14 @@ export function resolveAction(input: string, key: Key): GameAction | undefined {
 
   if (key.leftArrow) {
     return GameAction.MOVE_WEST;
+  }
+
+  if (input) {
+    const normalizedInput = input.toLowerCase();
+
+    if (Object.prototype.hasOwnProperty.call(characterBindings, normalizedInput)) {
+      return characterBindings[normalizedInput];
+    }
   }
 
   return undefined;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,20 @@
 import React, { useState, useEffect } from 'react';
-import { render, Text, Box } from 'ink';
+import { render, Box, Text } from 'ink';
 import { loadResources } from './engine/resourceManager.js';
 import { eventBus } from './engine/events.js';
+import type { GameState } from './engine/state.js';
+import GameScreen from './components/GameScreen.js';
+import { createInitialGameState } from './game/initialState.js';
 
 const App = () => {
-  const [message, setMessage] = useState('Initializing engine...');
+  const [statusMessage, setStatusMessage] = useState('Initializing engine...');
+  const [gameState, setGameState] = useState<GameState | null>(null);
 
   useEffect(() => {
     const initializeEngine = async () => {
       try {
         await loadResources('./data');
-        // Emit an event to signal that the engine is ready
-        eventBus.emit('engineReady', 'Engine Initialized Successfully!');
+        eventBus.emit('engineReady', 'Engine ready. Use WASD or the arrow keys to move.');
       } catch (error) {
         console.error(error);
         eventBus.emit('engineError', 'Failed to initialize engine.');
@@ -19,30 +22,35 @@ const App = () => {
     };
 
     const handleEngineReady = (newMessage: string) => {
-      setMessage(newMessage);
+      setStatusMessage(newMessage);
+      setGameState(createInitialGameState(newMessage));
     };
 
     const handleEngineError = (errorMessage: string) => {
-        setMessage(errorMessage);
-    }
+      setStatusMessage(errorMessage);
+      setGameState(null);
+    };
 
     eventBus.on('engineReady', handleEngineReady);
     eventBus.on('engineError', handleEngineError);
 
     initializeEngine();
 
-    // Cleanup listener on unmount
     return () => {
       eventBus.off('engineReady', handleEngineReady);
       eventBus.off('engineError', handleEngineError);
     };
   }, []);
 
-  return (
-    <Box borderStyle="round" padding={1}>
-      <Text>{message}</Text>
-    </Box>
-  );
+  if (!gameState) {
+    return (
+      <Box borderStyle="round" padding={1}>
+        <Text>{statusMessage}</Text>
+      </Box>
+    );
+  }
+
+  return <GameScreen initialState={gameState} statusMessage={statusMessage} />;
 };
 
 render(<App />);


### PR DESCRIPTION
## Summary
- add a type guard in `GameScreen` so northward actions (enum value 0) are no longer ignored
- expose and test the guard to prevent regressions where undefined actions are the only ones skipped

## Testing
- npm test *(fails: `jest` binary is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df75d20fac832b98666aa9820ac696