### PR TITLE
feat: Implement Field of View and Fog of War

### DIFF
--- a/ENGINE_DESIGN.md
+++ b/ENGINE_DESIGN.md
@@ -122,3 +122,15 @@
 2. Upon success, it emits `engineReady`; failures emit `engineError` for graceful degradation.【F:src/main.tsx†L10-L38】
 3. Subscribers (e.g., UI components, dev tooling) listen on `eventBus` to react, then instantiate the FSM, load initial `GameState` from cached resources, render `MapView`, and start collecting input.
 4. As gameplay progresses, systems call into the narrative engine to checkpoint, branch, and retrieve alternate timelines, maintaining the Git-like storytelling loop.【F:src/engine/narrativeEngine.ts†L22-L82】
+
+## 5. Future Enhancements
+
+This section outlines potential features that would round out the roguelike engine fundamentals before focusing on narrative content.
+
+-   **Advanced Enemy AI**: Move beyond simple `canWander` and `canChase` flags to implement more complex behaviors. This could include patrol routes, fleeing at low health, using special abilities, and A* pathfinding for more intelligent pursuit.
+-   **Equipment System**: Allow actors to equip items (weapons, armor, accessories) into specific slots to gain passive stat bonuses or effects. This would be a primary driver of player progression.
+-   **Status Effects System**: Implement a framework for applying temporary conditions to actors, such as `Poisoned`, `Stunned`, `Confused`, or `Hasted`. This would add significant tactical depth to combat.
+-   **Expanded Item & Magic System**: Introduce a wider variety of items like scrolls (one-shot effects), wands (charged items), and food (hunger mechanics). This could also serve as the foundation for a more formal skill or magic system.
+-   **Item Identification**: Add a classic roguelike mechanic where potions, scrolls, and other magical items are initially unidentified, forcing the player to discover their properties through use or other means.
+-   **Persistent Save/Load**: Implement serialization for the entire game state, including the narrative engine's history, allowing players to save and resume their sessions.
+-   **Detailed Message Log**: Expand the UI to include a scrollable history of game messages, allowing the player to review past events and understand the flow of combat.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This project implements several classic roguelike mechanics to create a challeng
 *   **Environmental Interactions:** The dungeon is not just a static backdrop. Interact with doors to open them and loot chests to find valuable items.
 *   **Multi-Level Dungeons:** Explore a persistent, multi-level dungeon with interconnected floors.
 *   **Dungeon Themes:** Each floor has a unique theme with different enemies, items, and visuals.
+*   **Field of View / Fog of War:** The player's view is limited to what their character can see. Explored areas are remembered and displayed in a dimmed "fog of war."
 
 ## 3. Controls
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,23 +1,10 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  // No preset, we'll configure manually
+  // Use the official ts-jest preset for ES Modules
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  // Tells Jest to use ES Modules
-  extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  // The module name mapper is still needed to resolve .js extensions in imports
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-  },
-  // The transform configuration for ts-jest
-  transform: {
-    '^.+\\.(t|j)sx?$': [
-      'ts-jest',
-      {
-        useESM: true,
-        // tsconfig might be needed if you have a specific one for tests
-        // tsconfig: 'tsconfig.test.json'
-      },
-    ],
   },
   // By default, Jest ignores node_modules. We need to tell it to *not* ignore rot-js
   // because it's published as an ES module and needs to be transformed.

--- a/src/components/CombatMenuView.test.tsx
+++ b/src/components/CombatMenuView.test.tsx
@@ -40,6 +40,8 @@ const mockGameState: GameState = {
   floorStates: new Map(),
   combatTargetId: 'enemy-1',
   selectedCombatMenuIndex: 0,
+  visibleTiles: new Set<string>(),
+  exploredTiles: new Set<string>(),
 };
 
 describe('CombatMenuView', () => {

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -26,50 +26,70 @@ interface DisplayTile {
   char: string;
   color: string;
   backgroundColor?: string;
+  isDim: boolean;
 }
 
-const createDisplayGrid = (state: GameState): DisplayTile[][] => {
-  const { actors, items, entities, map } = state;
+const createDisplayGrid = (state: GameState): (DisplayTile | null)[][] => {
+  const { actors, items, entities, map, visibleTiles, exploredTiles } = state;
 
-  const displayGrid: DisplayTile[][] = map.tiles.map((row) =>
-    row.map((tile) => ({
-      char: tile.char,
-      color: tile.walkable ? 'grey' : 'white',
-    }))
+  const displayGrid: (DisplayTile | null)[][] = map.tiles.map((row, y) =>
+    row.map((tile, x) => {
+      const coord = `${x},${y}`;
+      const isVisible = visibleTiles.has(coord);
+      const isExplored = exploredTiles.has(coord);
+
+      if (!isVisible && !isExplored) {
+        return null; // Unexplored tile
+      }
+
+      return {
+        char: tile.char,
+        color: tile.walkable ? 'grey' : 'white',
+        isDim: !isVisible,
+      };
+    })
   );
 
   const allEntities: (Entity | Actor | Item)[] = [...items, ...entities, ...actors];
 
   for (const entity of allEntities) {
+    const { x, y } = entity.position;
+    const coord = `${x},${y}`;
+
     if (
-      entity.position.y >= 0 &&
-      entity.position.y < map.height &&
-      entity.position.x >= 0 &&
-      entity.position.x < map.width
+      visibleTiles.has(coord) &&
+      y >= 0 &&
+      y < map.height &&
+      x >= 0 &&
+      x < map.width &&
+      displayGrid[y][x] // Make sure we don't try to update a null tile (shouldn't happen)
     ) {
-      displayGrid[entity.position.y][entity.position.x] = {
-        ...displayGrid[entity.position.y][entity.position.x],
-        char: entity.char,
-        color: entity.color || 'white',
-      };
+      displayGrid[y][x]!.char = entity.char;
+      displayGrid[y][x]!.color = entity.color || 'white';
+      displayGrid[y][x]!.isDim = false; // Entities are only drawn if visible
     }
   }
 
   const player = actors.find((a) => a.isPlayer);
   if (player) {
-    displayGrid[player.position.y][player.position.x].backgroundColor =
-      'yellow';
-    displayGrid[player.position.y][player.position.x].color = 'black';
+    const { x, y } = player.position;
+    if (displayGrid[y]?.[x]) {
+      displayGrid[y][x]!.backgroundColor = 'yellow';
+      displayGrid[y][x]!.color = 'black';
+      displayGrid[y][x]!.isDim = false;
+    }
   }
 
   return displayGrid;
 };
 
 const MapView: React.FC<Props> = ({ state, isDimmed }) => {
-  const { actors, message, messageType } = state;
+  const { actors, message, messageType, visibleTiles } = state;
   const player = actors.find((a) => a.isPlayer);
   const displayGrid = createDisplayGrid(state);
-  const enemies = actors.filter((a) => !a.isPlayer);
+  const visibleEnemies = actors.filter(
+    (a) => !a.isPlayer && visibleTiles.has(`${a.position.x},${a.position.y}`)
+  );
 
   return (
     <Box flexDirection="column" paddingX={2}>
@@ -95,22 +115,27 @@ const MapView: React.FC<Props> = ({ state, isDimmed }) => {
         <Box flexDirection="column" alignItems="flex-start">
           {displayGrid.map((row, y) => (
             <Box key={y} flexDirection="row">
-              {row.map((tile, x) => (
-                <Text
-                  key={`${x},${y}`}
-                  color={tile.color}
-                  backgroundColor={tile.backgroundColor}
-                  dimColor={isDimmed}
-                >
-                  {tile.char}{' '}
-                </Text>
-              ))}
+              {row.map((tile, x) => {
+                if (tile === null) {
+                  return <Text key={`${x},${y}`}>  </Text>; // Render empty space for unexplored tiles
+                }
+                return (
+                  <Text
+                    key={`${x},${y}`}
+                    color={tile.color}
+                    backgroundColor={tile.backgroundColor}
+                    dimColor={isDimmed || tile.isDim}
+                  >
+                    {tile.char}{' '}
+                  </Text>
+                );
+              })}
             </Box>
           ))}
         </Box>
 
         {/* Side Panel for Enemy Status */}
-        {enemies.length > 0 && (
+        {visibleEnemies.length > 0 && (
           <Box
             flexDirection="column"
             marginLeft={4}
@@ -119,9 +144,9 @@ const MapView: React.FC<Props> = ({ state, isDimmed }) => {
             borderColor="gray"
           >
             <Text bold dimColor={isDimmed}>
-              Enemies
+              Visible Enemies
             </Text>
-            {enemies.map((enemy) => (
+            {visibleEnemies.map((enemy) => (
               <Text key={enemy.id} dimColor={isDimmed}>
                 <Text color={enemy.color || 'white'}>
                   {enemy.name} ({enemy.char})

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -85,6 +85,8 @@ export interface GameState {
   };
   message: string;
   messageType: MessageType;
+  visibleTiles: Set<string>; // "x,y" format for quick lookups
+  exploredTiles: Set<string>; // "x,y" format for quick lookups
   selectedItemIndex?: number;
   target?: Point;
   currentFloor: number;

--- a/src/game/combat.test.ts
+++ b/src/game/combat.test.ts
@@ -64,6 +64,8 @@ const mockGameState: GameState = {
   messageType: 'info',
   currentFloor: 1,
   floorStates: new Map(),
+  visibleTiles: new Set<string>(),
+  exploredTiles: new Set<string>(),
 };
 
 describe('calculateDamage', () => {

--- a/src/game/combatMenu.test.ts
+++ b/src/game/combatMenu.test.ts
@@ -40,6 +40,8 @@ const mockGameState: GameState = {
   floorStates: new Map(),
   combatTargetId: 'enemy-1',
   selectedCombatMenuIndex: 0,
+  visibleTiles: new Set<string>(),
+  exploredTiles: new Set<string>(),
 };
 
 describe('Combat Menu Logic', () => {

--- a/src/game/fov.ts
+++ b/src/game/fov.ts
@@ -1,0 +1,31 @@
+import { FOV } from 'rot-js';
+import type { GameState, Point } from '../engine/state.js';
+
+/**
+ * Calculates the player's field of view.
+ *
+ * @param map - The game map.
+ * @param playerPosition - The player's current position.
+ * @param radius - The radius of the FOV.
+ * @returns A Set of visible tile coordinates in "x,y" format.
+ */
+export const calculateFov = (
+  map: GameState['map'],
+  playerPosition: Point,
+  radius: number
+): Set<string> => {
+  const fov = new FOV.PreciseShadowcasting((x, y) => {
+    if (x < 0 || y < 0 || x >= map.width || y >= map.height) {
+      return false;
+    }
+    return map.tiles[y][x].transparent;
+  });
+
+  const visibleTiles = new Set<string>();
+
+  fov.compute(playerPosition.x, playerPosition.y, radius, (x, y) => {
+    visibleTiles.add(`${x},${y}`);
+  });
+
+  return visibleTiles;
+};

--- a/src/game/initialState.ts
+++ b/src/game/initialState.ts
@@ -10,6 +10,7 @@ import type {
 } from '../engine/state.js';
 import { generateMap } from './map-generation.js';
 import { getResource } from '../engine/resourceManager.js';
+import { updateVisibility } from './visibility.js';
 
 const MAP_WIDTH = 80;
 const MAP_HEIGHT = 24;
@@ -166,7 +167,7 @@ export function createInitialGameState(options: InitialStateOptions = {}): GameS
     }
   }
 
-  return {
+  const baseState: GameState = {
     phase: 'PlayerTurn',
     actors,
     items,
@@ -180,5 +181,9 @@ export function createInitialGameState(options: InitialStateOptions = {}): GameS
     messageType: 'info',
     currentFloor: floor,
     floorStates,
+    visibleTiles: new Set<string>(),
+    exploredTiles: new Set<string>(),
   };
+
+  return updateVisibility(baseState);
 }

--- a/src/game/interaction.test.ts
+++ b/src/game/interaction.test.ts
@@ -29,6 +29,8 @@ const createInitialState = (door: Entity): GameState => ({
   messageType: 'info',
   currentFloor: 1,
   floorStates: new Map(),
+  visibleTiles: new Set<string>(),
+  exploredTiles: new Set<string>(),
 });
 
 describe('handleInteraction', () => {

--- a/src/game/updateState.ts
+++ b/src/game/updateState.ts
@@ -4,6 +4,7 @@ import { GameAction } from '../input/actions.js';
 import { createInitialGameState } from './initialState.js';
 import { runEnemyTurn } from './ai.js';
 import { resolveAttack } from './combat.js';
+import { updateVisibility } from './visibility.js';
 
 interface MovementDelta {
   dx: number;
@@ -203,13 +204,13 @@ export function handleInteraction(state: GameState, x: number, y: number): GameS
         })
       );
 
-      newState = {
+      newState = updateVisibility({
         ...state,
         entities: newEntities,
         map: { ...state.map, tiles: newTiles },
         message: newIsOpen ? 'You open the door.' : 'You close the door.',
         phase: 'EnemyTurn',
-      };
+      });
       break;
     }
 
@@ -271,7 +272,8 @@ export function handleInteraction(state: GameState, x: number, y: number): GameS
       const nextFloor = direction === 'down' ? currentFloor + 1 : currentFloor - 1;
 
       if (floorStates.has(nextFloor)) {
-        newState = floorStates.get(nextFloor)!;
+        // Recalculate visibility upon returning to a floor
+        newState = updateVisibility(floorStates.get(nextFloor)!);
       } else {
         newState = createInitialGameState({
           player,
@@ -471,14 +473,14 @@ function handlePlayerAction(state: GameState, action: GameAction): GameState {
       : actor
   );
 
-  return {
+  return updateVisibility({
     ...state,
     actors: actorsAfterPlayerMove,
     items: state.items,
     message: delta.successMessage,
     messageType: 'info',
     phase: 'EnemyTurn',
-  };
+  });
 }
 
 function handleEnemyTurns(state: GameState): GameState {

--- a/src/game/visibility.ts
+++ b/src/game/visibility.ts
@@ -1,0 +1,28 @@
+import type { GameState } from '../engine/state.js';
+import { calculateFov } from './fov.js';
+
+const FOV_RADIUS = 8;
+
+/**
+ * Updates the visible and explored tiles in the game state based on the player's position.
+ * @param state The current game state.
+ * @returns A new game state with updated visibility information.
+ */
+export function updateVisibility(state: GameState): GameState {
+  const player = state.actors.find((a) => a.isPlayer);
+  if (!player) {
+    return state;
+  }
+
+  const visibleTiles = calculateFov(state.map, player.position, FOV_RADIUS);
+
+  // `exploredTiles` might not be initialized on the very first state creation,
+  // so we handle that case.
+  const exploredTiles = new Set([...(state.exploredTiles || []), ...visibleTiles]);
+
+  return {
+    ...state,
+    visibleTiles,
+    exploredTiles,
+  };
+}


### PR DESCRIPTION
This commit introduces a Field of View (FOV) and Fog of War system, a fundamental feature for roguelike games.

Key changes:
- **Game State:** The `GameState` interface in `src/engine/state.ts` is updated with `visibleTiles` and `exploredTiles` sets to track visibility.
- **FOV Calculation:** A new `fov.ts` module uses the `rot-js` library to calculate the set of visible tiles from the player's perspective.
- **Visibility Logic:** A new `visibility.ts` module centralizes the logic for updating the FOV and explored tiles. This is called after every player move, interaction with doors, and when changing floors.
- **UI Rendering:** The `MapView.tsx` component is updated to render the map based on three states:
    1.  Unexplored tiles are not rendered (blank).
    2.  Explored but not currently visible tiles are rendered with a dim color (Fog of War).
    3.  Currently visible tiles are rendered normally.
- **Enemy Panel:** The enemy status panel now only shows enemies that are currently visible to the player.
- **Documentation:** `README.md` and `ENGINE_DESIGN.md` have been updated to reflect the new feature and list other potential engine enhancements.
- **Testing:** Fixed a bug in the Jest configuration and updated all mock `GameState` objects in test files to accommodate the new state properties, ensuring the test suite passes.